### PR TITLE
修改研讨界面左侧导航配色

### DIFF
--- a/src/components/Talk/ContactItem.vue
+++ b/src/components/Talk/ContactItem.vue
@@ -52,7 +52,7 @@ export default {
 
 <style lang="less" scoped>
   .activated {
-    background-color: rgb(195, 197, 199)!important;
+    background-color: #d3d6dc!important;
   }
   .on-line {
     color: rgba(43, 162, 69, 1);
@@ -65,11 +65,11 @@ export default {
     cursor: pointer;
     overflow: hidden;
     padding: 10px 18px 9px;
-    background-color: rgb(230, 232, 235);
+    background-color: #ebeff5;
     border-bottom: 1px solid rgb(218, 220, 223);
 
     &:hover {
-      background-color: rgb(215, 217, 219);
+      background-color: #d3d6dc99;
     }
 
   }

--- a/src/components/Talk/GroupItem.vue
+++ b/src/components/Talk/GroupItem.vue
@@ -66,7 +66,7 @@ export default {
 
 <style lang="less" scoped>
   .activated {
-    background-color: rgb(195, 197, 199)!important;
+    background-color: #d3d6dc!important;
   }
   .on-line {
     color: rgba(43, 162, 69, 1);
@@ -79,11 +79,11 @@ export default {
     cursor: pointer;
     overflow: hidden;
     padding: 10px 18px 9px;
-    background-color: rgb(230, 232, 235);
+    background-color: #ebeff5;
     border-bottom: 1px solid rgb(218, 220, 223);
 
     &:hover {
-      background-color: rgb(215, 217, 219);
+      background-color: #d3d6dc99;
     }
 
   }

--- a/src/components/Talk/RecentContactsItem.vue
+++ b/src/components/Talk/RecentContactsItem.vue
@@ -111,11 +111,11 @@ export default {
 <style lang="less" scoped>
 
   .activated {
-    background-color: rgb(195, 197, 199)!important;
+    background-color: #d3d6dc!important;
   }
 
   .top {
-    background-color: rgb(220, 222, 224)!important;
+    background-color: #e6e9ed!important;
   }
 
   .recent-contacts {
@@ -126,11 +126,11 @@ export default {
     cursor: pointer;
     overflow: hidden;
     padding: 12px 18px 11px;
-    background-color: rgb(230, 232, 235);
+    background-color: #ebeff5;
     border-bottom: 1px solid rgb(218, 220, 223);
 
     &:hover {
-      background-color: rgb(215, 217, 219);
+      background-color: #d4d7dc99;
     }
   }
 

--- a/src/components/Talk/SearchAll.vue
+++ b/src/components/Talk/SearchAll.vue
@@ -179,7 +179,7 @@ export default {
       height: 31px;
       border-radius: 4px;
       z-index: 10;
-      background-color: #a7a8ac;
+      background-color: #a9adb8;
       opacity: 0.5;
       pointer-events: none;
       border: 1px solid #d1d2d4;
@@ -188,7 +188,7 @@ export default {
 
   .result-container {
     height: calc(100vh - 119px);
-    background-color: #e6e8eb;
+    background-color: #ebeff5;
     margin: -24px;
     border-top: 1px #d5d8de solid;
     overflow: auto;
@@ -197,7 +197,7 @@ export default {
       margin: 0;
       padding-left: 17px;
       color: #a0a1a5;
-      background-color: #dcdcdc;
+      background-color: #e6e9ed;
       border-bottom: 1px #d5d8de solid;
     }
   }

--- a/src/views/talk/ChatPanel.vue
+++ b/src/views/talk/ChatPanel.vue
@@ -279,7 +279,7 @@ export default {
   max-width: 280px !important;
   flex: 0 0 280px !important;
 
-  background: rgb(230, 232, 235);
+  background-color: #ebeff5;
   border-right: 1px solid #dcdee0;
 
   // 聊天搜索栏样式 该部分高度为48px
@@ -290,7 +290,7 @@ export default {
       margin-left: 10px;
       width: 31px;
       height: 31px;
-      background: #d1d2d4;
+      background-color: #d3d6dc;
       color: #7c7a7a;
       font-size: 18px;
     }


### PR DESCRIPTION
- 背景色：`#ebeff5`
- 置顶：`#e6e9ed`
- 选中：`#d3d6dc`
- 悬停：`#d3d6dc`